### PR TITLE
Add login persistence and guard activities

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,9 +13,10 @@
         tools:targetApi="31">
 
         <activity android:name=".ListaTarefasActivity" />
-
+        <activity android:name=".MainActivity" />
+        <activity android:name=".RegisterActivity" />
         <activity
-            android:name=".MainActivity"
+            android:name=".LoginActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/troca_tela/DBHelper.java
+++ b/app/src/main/java/com/example/troca_tela/DBHelper.java
@@ -10,8 +10,10 @@ import java.util.ArrayList;
 public class DBHelper extends SQLiteOpenHelper {
 
     private static final String DB_NAME = "tarefas.db";
-    private static final int DB_VERSION = 1;
-    private static final String TABLE_NAME = "tarefas";
+    private static final int DB_VERSION = 2; // incremented for user table
+
+    private static final String TABLE_TAREFAS = "tarefas";
+    private static final String TABLE_USUARIOS = "usuarios";
 
     public DBHelper(Context context) {
         super(context, DB_NAME, null, DB_VERSION);
@@ -19,40 +21,75 @@ public class DBHelper extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase db) {
-        String query = "CREATE TABLE " + TABLE_NAME + " (" +
+        String createUsuarios = "CREATE TABLE " + TABLE_USUARIOS + " (" +
                 "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
-                "descricao TEXT, data TEXT, hora TEXT, prioridade TEXT)";
-        db.execSQL(query);
+                "usuario TEXT UNIQUE, senha TEXT)";
+        db.execSQL(createUsuarios);
+
+        String createTarefas = "CREATE TABLE " + TABLE_TAREFAS + " (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "user_id INTEGER, descricao TEXT, data TEXT, hora TEXT, prioridade TEXT, " +
+                "FOREIGN KEY(user_id) REFERENCES " + TABLE_USUARIOS + "(id))";
+        db.execSQL(createTarefas);
     }
-    public void excluirTarefa(Model tarefa) {
+
+    // region Usuários
+    public long inserirUsuario(String usuario, String senha) {
         SQLiteDatabase db = this.getWritableDatabase();
-        db.delete("tarefas", "descricao=? AND data=? AND hora=? AND prioridade=?",
-                new String[]{tarefa.getDescricao(), tarefa.getData(), tarefa.getHora(), tarefa.getPrioridade()});
+        ContentValues cv = new ContentValues();
+        cv.put("usuario", usuario);
+        cv.put("senha", senha);
+        long id = db.insert(TABLE_USUARIOS, null, cv);
+        db.close();
+        return id;
+    }
+
+    public int autenticarUsuario(String usuario, String senha) {
+        SQLiteDatabase db = this.getReadableDatabase();
+        Cursor c = db.rawQuery("SELECT id FROM " + TABLE_USUARIOS + " WHERE usuario=? AND senha=?",
+                new String[]{usuario, senha});
+        int userId = -1;
+        if (c.moveToFirst()) {
+            userId = c.getInt(c.getColumnIndexOrThrow("id"));
+        }
+        c.close();
+        db.close();
+        return userId;
+    }
+    // endregion
+    public void excluirTarefa(Model tarefa, int userId) {
+        SQLiteDatabase db = this.getWritableDatabase();
+        db.delete(TABLE_TAREFAS,
+                "user_id=? AND descricao=? AND data=? AND hora=? AND prioridade=?",
+                new String[]{String.valueOf(userId), tarefa.getDescricao(), tarefa.getData(), tarefa.getHora(), tarefa.getPrioridade()});
         db.close();
     }
 
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int i, int i1) {
-        db.execSQL("DROP TABLE IF EXISTS " + TABLE_NAME);
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_TAREFAS);
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_USUARIOS);
         onCreate(db);
     }
 
-    public void inserirTarefa(Model tarefa) {
+    public void inserirTarefa(Model tarefa, int userId) {
         SQLiteDatabase db = this.getWritableDatabase();
         ContentValues cv = new ContentValues();
+        cv.put("user_id", userId);
         cv.put("descricao", tarefa.getDescricao());
         cv.put("data", tarefa.getData());
         cv.put("hora", tarefa.getHora());
         cv.put("prioridade", tarefa.getPrioridade());
-        db.insert(TABLE_NAME, null, cv);
+        db.insert(TABLE_TAREFAS, null, cv);
         db.close();
     }
 
-    public ArrayList<Model> getTodasTarefas() {
+    public ArrayList<Model> getTarefasUsuario(int userId) {
         ArrayList<Model> lista = new ArrayList<>();
         SQLiteDatabase db = this.getReadableDatabase();
-        Cursor cursor = db.rawQuery("SELECT * FROM " + TABLE_NAME, null);
+        Cursor cursor = db.rawQuery("SELECT descricao, data, hora, prioridade FROM " + TABLE_TAREFAS + " WHERE user_id=?",
+                new String[]{String.valueOf(userId)});
 
         if (cursor.moveToFirst()) {
             do {

--- a/app/src/main/java/com/example/troca_tela/ListaTarefasActivity.java
+++ b/app/src/main/java/com/example/troca_tela/ListaTarefasActivity.java
@@ -1,5 +1,7 @@
 package com.example.troca_tela;
 
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.widget.Button;
 
@@ -14,6 +16,7 @@ public class ListaTarefasActivity extends AppCompatActivity {
     RecyclerView recyclerView;
     TarefaAdapter adapter;
     DBHelper dbHelper;
+    int userId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -24,7 +27,18 @@ public class ListaTarefasActivity extends AppCompatActivity {
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
         dbHelper = new DBHelper(this);
-        ArrayList<Model> listaTarefas = dbHelper.getTodasTarefas();
+        userId = getIntent().getIntExtra("user_id", -1);
+        if (userId == -1) {
+            SharedPreferences prefs = getSharedPreferences("app", MODE_PRIVATE);
+            userId = prefs.getInt("user_id", -1);
+        }
+        if (userId == -1) {
+            startActivity(new Intent(this, LoginActivity.class));
+            finish();
+            return;
+        }
+
+        ArrayList<Model> listaTarefas = dbHelper.getTarefasUsuario(userId);
 
         adapter = new TarefaAdapter(listaTarefas);
         recyclerView.setAdapter(adapter);

--- a/app/src/main/java/com/example/troca_tela/LoginActivity.java
+++ b/app/src/main/java/com/example/troca_tela/LoginActivity.java
@@ -1,0 +1,58 @@
+package com.example.troca_tela;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.content.SharedPreferences;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class LoginActivity extends AppCompatActivity {
+    EditText edtUsuario, edtSenha;
+    DBHelper dbHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_login);
+
+        SharedPreferences prefs = getSharedPreferences("app", MODE_PRIVATE);
+        int savedId = prefs.getInt("user_id", -1);
+        if (savedId != -1) {
+            Intent i = new Intent(this, MainActivity.class);
+            i.putExtra("user_id", savedId);
+            startActivity(i);
+            finish();
+            return;
+        }
+
+        edtUsuario = findViewById(R.id.edtUsuario);
+        edtSenha = findViewById(R.id.edtSenha);
+        Button btnEntrar = findViewById(R.id.btnEntrar);
+        Button btnCadastrar = findViewById(R.id.btnCadastrar);
+        dbHelper = new DBHelper(this);
+
+        btnEntrar.setOnClickListener(v -> realizarLogin());
+        btnCadastrar.setOnClickListener(v -> startActivity(new Intent(this, RegisterActivity.class)));
+    }
+
+    private void realizarLogin() {
+        String usuario = edtUsuario.getText().toString().trim();
+        String senha = edtSenha.getText().toString().trim();
+        int id = dbHelper.autenticarUsuario(usuario, senha);
+        if (id != -1) {
+            getSharedPreferences("app", MODE_PRIVATE)
+                    .edit().putInt("user_id", id).apply();
+
+            Intent i = new Intent(this, MainActivity.class);
+            i.putExtra("user_id", id);
+            startActivity(i);
+            finish();
+        } else {
+            Toast.makeText(this, "Credenciais incorretas", Toast.LENGTH_SHORT).show();
+        }
+    }
+}

--- a/app/src/main/java/com/example/troca_tela/MainActivity.java
+++ b/app/src/main/java/com/example/troca_tela/MainActivity.java
@@ -1,6 +1,7 @@
 package com.example.troca_tela;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.*;
@@ -11,7 +12,8 @@ public class MainActivity extends AppCompatActivity {
 
     EditText edtDescricao, edtData, edtHora;
     Spinner spinnerPrioridade;
-    DBHelper dbHelper; // 🆕 Banco de dados SQLite
+    DBHelper dbHelper; // Banco de dados SQLite
+    int userId; // id do usuário logado
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -23,7 +25,18 @@ public class MainActivity extends AppCompatActivity {
         edtHora = findViewById(R.id.edtHora);
         spinnerPrioridade = findViewById(R.id.spinnerPrioridade);
 
-        dbHelper = new DBHelper(this); // 🆕 Inicializa o banco
+        dbHelper = new DBHelper(this);
+
+        userId = getIntent().getIntExtra("user_id", -1);
+        if (userId == -1) {
+            SharedPreferences prefs = getSharedPreferences("app", MODE_PRIVATE);
+            userId = prefs.getInt("user_id", -1);
+        }
+        if (userId == -1) {
+            startActivity(new Intent(this, LoginActivity.class));
+            finish();
+            return;
+        }
 
         ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(this,
                 R.array.opcoes_prioridade, android.R.layout.simple_spinner_item);
@@ -37,6 +50,12 @@ public class MainActivity extends AppCompatActivity {
         String hora = edtHora.getText().toString().trim();
         String prioridade = spinnerPrioridade.getSelectedItem().toString();
 
+        if (userId == -1) {
+            startActivity(new Intent(this, LoginActivity.class));
+            finish();
+            return;
+        }
+
         if (desc.isEmpty() || data.isEmpty() || hora.isEmpty()) {
             Toast.makeText(this, "Preencha todos os campos!", Toast.LENGTH_SHORT).show();
             return;
@@ -44,7 +63,7 @@ public class MainActivity extends AppCompatActivity {
 
         Model tarefa = new Model(desc, data, hora, prioridade);
 
-        dbHelper.inserirTarefa(tarefa); // 🆕 salva no banco
+        dbHelper.inserirTarefa(tarefa, userId); // salva no banco
 
         Toast.makeText(this, "Tarefa salva no banco!", Toast.LENGTH_SHORT).show();
 
@@ -55,6 +74,20 @@ public class MainActivity extends AppCompatActivity {
         spinnerPrioridade.setSelection(0);
 
         // Ir para tela de lista
-        startActivity(new Intent(this, ListaTarefasActivity.class));
+        Intent intent = new Intent(this, ListaTarefasActivity.class);
+        intent.putExtra("user_id", userId);
+        startActivity(intent);
+    }
+
+    public void abrirLista(View view) {
+        if (userId == -1) {
+            startActivity(new Intent(this, LoginActivity.class));
+            finish();
+            return;
+        }
+
+        Intent intent = new Intent(this, ListaTarefasActivity.class);
+        intent.putExtra("user_id", userId);
+        startActivity(intent);
     }
 }

--- a/app/src/main/java/com/example/troca_tela/RegisterActivity.java
+++ b/app/src/main/java/com/example/troca_tela/RegisterActivity.java
@@ -1,0 +1,45 @@
+package com.example.troca_tela;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class RegisterActivity extends AppCompatActivity {
+    EditText edtUsuario, edtSenha;
+    DBHelper dbHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_register);
+
+        edtUsuario = findViewById(R.id.edtUsuarioCadastro);
+        edtSenha = findViewById(R.id.edtSenhaCadastro);
+        Button btnRegistrar = findViewById(R.id.btnRegistrar);
+        dbHelper = new DBHelper(this);
+
+        btnRegistrar.setOnClickListener(v -> realizarCadastro());
+    }
+
+    private void realizarCadastro() {
+        String usuario = edtUsuario.getText().toString().trim();
+        String senha = edtSenha.getText().toString().trim();
+        if (usuario.isEmpty() || senha.isEmpty()) {
+            Toast.makeText(this, "Preencha usuario e senha", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        long id = dbHelper.inserirUsuario(usuario, senha);
+        if (id != -1) {
+            Toast.makeText(this, "Cadastro realizado", Toast.LENGTH_SHORT).show();
+            Intent i = new Intent(this, LoginActivity.class);
+            startActivity(i);
+            finish();
+        } else {
+            Toast.makeText(this, "Erro ao cadastrar", Toast.LENGTH_SHORT).show();
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:gravity="center"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/edtUsuario"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Usuário" />
+
+    <EditText
+        android:id="@+id/edtSenha"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Senha"
+        android:inputType="textPassword"
+        android:layout_marginTop="8dp" />
+
+    <Button
+        android:id="@+id/btnEntrar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Entrar"
+        android:layout_marginTop="16dp" />
+
+    <Button
+        android:id="@+id/btnCadastrar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Cadastrar"
+        android:layout_marginTop="8dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -80,5 +80,13 @@
             android:textSize="16sp"
             android:textColor="@android:color/white"
             android:backgroundTint="#4CAF50" />
+
+        <Button
+            android:id="@+id/btnListar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Ver Tarefas"
+            android:onClick="abrirLista"
+            android:layout_marginTop="8dp"/>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:gravity="center"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/edtUsuarioCadastro"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Usuário" />
+
+    <EditText
+        android:id="@+id/edtSenhaCadastro"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Senha"
+        android:inputType="textPassword"
+        android:layout_marginTop="8dp" />
+
+    <Button
+        android:id="@+id/btnRegistrar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Registrar"
+        android:layout_marginTop="16dp" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,8 @@
         <item>Média</item>
         <item>Baixa</item>
     </string-array>
+
+    <string name="login">Entrar</string>
+    <string name="register">Registrar</string>
+    <string name="no_account">Cadastrar</string>
 </resources>


### PR DESCRIPTION
## Summary
- persist logged-in user in shared preferences
- check stored user ID before showing activities
- redirect to login when no user ID is available

## Testing
- `./gradlew test --console=plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684840ea7bb8832f82fe6abe7e0bd82d